### PR TITLE
Add support for 'auto' run duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The action accepts the follow inputs:
 | ✔️ | `api-url` | string | URL to your running API. *Example:* http://localhost:8000/api/v1 |
 | ✔️ | `api-spec` | string | Path or URL to your Swagger spec, OpenAPI spec, or Postman collection.|
 |   | `target` | string | The organization-scoped name of your target, such as `forallsecure/mapi-action-example` | auto-generated from your GitHub Repository name
-|   | `duration` | number | Duration of scan, in seconds | 60sec
+|   | `duration` | number/string | Duration of scan. 'auto' for automatic duration. Otherwise time (ie: '30sec', '5min', '1h', '1h30m') | auto
 |   | `html-report` | string | Path to the generated SARIF report |
 |   | `sarif-report` | string | Path to the generated HTML report |
 |   | `run-args` | string | Additional arguments to provide to the `mapi run` command. |

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: The organization-scoped name of your target, such as example/my-test-target. Auto-generated from your GitHub Repository name if unspecified.
   duration:
     description: Scan duration
-    default: 60sec
+    default: auto
   sarif-report:
     description: SARIF output path. You can upload ot to GitHub using the 'github/codeql-action/upload-sarif@v1' action
   html-report:

--- a/workflow.yml
+++ b/workflow.yml
@@ -50,7 +50,6 @@ jobs:
           mapi-token: ${{ secrets.MAPI_TOKEN }}
           api-url: "http://localhost:8080"               # <- update this
           api-spec: "http://localhost:8080/openapi.json" # <- update this
-          duration: 60sec
           sarif-report: mapi.sarif
           html-report: mapi.html
           run-args: |                                   # <- Additional run args


### PR DESCRIPTION
* Default run duration (if unspecified) is now `auto`
* Duration overrides will continue to work as they do today