### PR TITLE
Update action.yml deps with node16 instead of node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
   run-args:
     description: A list of additional arguments (separated by '\n') to include in the call to 'mapi run'. Run 'mapi run --help' for a complete list of arguments.
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'shield'


### PR DESCRIPTION
Fixes for https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/