### PR TITLE
Add warning about using quotes in `run-args` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The action accepts the follow inputs:
 |   | `duration` | number/string | Duration of scan. 'auto' for automatic duration. Otherwise time (ie: '30sec', '5min', '1h', '1h30m') | auto
 |   | `html-report` | string | Path to the generated SARIF report |
 |   | `sarif-report` | string | Path to the generated HTML report |
-|   | `run-args` | string | Additional arguments to provide to the `mapi run` command.  Argument values should be separated on new lines. <br><br>e.g.<br> <pre>  run-args: \|<br>    # Basic Auth<br>    --basic-auth<br>    login:password</pre>|
+|   | `run-args` | string | Additional arguments to provide to the `mapi run` command.  Argument values should be separated on new lines. <br><br>e.g.<br> <pre>  run-args: \|<br>    # Basic Auth<br>    --basic-auth<br>    login:password</pre><br>⚠️ Avoid wrapping values in quotes, as these will be escaped and included in the value passed to `mapi`.<br><br>⛔️ `"login:password"` <br>✅ `login:password` |
 
 ### Continuing on error
 


### PR DESCRIPTION
This is a common mistake, document it!